### PR TITLE
Added negative_failure_message function

### DIFF
--- a/lib/rspec-instrumentation-matcher.rb
+++ b/lib/rspec-instrumentation-matcher.rb
@@ -39,8 +39,12 @@ module RSpec
 
         end
 
-        def failure_message
-          message = "Expected #{@subject} to be instrumented"
+        def negative_failure_message
+          failure_message(true)
+        end
+
+        def failure_message(negative = false)
+          message = "Expected #{@subject} #{"not " if negative}to be instrumented"
           message << " at least #{count @at_least}" unless at_least?
           message << " at most #{count @at_most}" unless at_most?
           message << " exactly #{count @times}" unless times?

--- a/lib/rspec-instrumentation-matcher/version.rb
+++ b/lib/rspec-instrumentation-matcher/version.rb
@@ -1,7 +1,7 @@
 module Rspec
   module Instrumentation
     module Matcher
-      VERSION = "0.0.4"
+      VERSION = "0.0.5"
     end
   end
 end


### PR DESCRIPTION
If you try to use a negative matcher like

    expect{subject.perform(12)}.not_to instrument('offers_loader.tender_offers_loaded')

an error occur:

    undefined method `negative_failure_message' for #<RSpec::Instrumentation::Matcher::InstrumentMatcher:0x0000010a8a7b58>

This pull request adds the missing method.