### PR TITLE
Fix uninitialized constant RSpec::Matchers (NameError) again

### DIFF
--- a/lib/rspec-instrumentation-matcher.rb
+++ b/lib/rspec-instrumentation-matcher.rb
@@ -1,5 +1,6 @@
 require 'rspec-instrumentation-matcher/version'
 require 'active_support/notifications'
+require 'rspec/matchers'
 module RSpec
   module Instrumentation
     module Matcher
@@ -154,7 +155,6 @@ module RSpec
   end
 end
 
-require 'rspec/matchers'
 module RSpec::Matchers
   include RSpec::Instrumentation::Matcher
 end


### PR DESCRIPTION
First at all, thank you for nice gem. It helps me so much to test around instrumentation :)

But I got trouble to use this gem with error message `uninitialized constant RSpec::Matchers (NameError)` when rails server or rails console.
So I fixed to place `require` at top of module and it works.

This problem will reproduced by next steps
- `rails new some_app`
- write `gem 'rspec-instrumentation-matcher'` to Gemfile
- `bundle install`
- `rails server` or `rails console`

I tested it with
- ruby 2.5.5
- rails 5.1.5 and 5.2.4